### PR TITLE
do not add completion install options

### DIFF
--- a/src/catleg/catleg.py
+++ b/src/catleg/catleg.py
@@ -9,7 +9,7 @@ from catleg.find_changes import find_changes
 from catleg.query import get_backend
 from catleg.skeleton import markdown_skeleton
 
-app = typer.Typer()
+app = typer.Typer(add_completion=False)
 # legifrance-specific commands (query legifrance API and return
 # raw JSON)
 lf = typer.Typer()


### PR DESCRIPTION
I think displaying the install message is not very helpful and mostly noise.

Disabling it means that instead of showing this help screen:
![image](https://github.com/CatalaLang/catleg/assets/10352819/9397ff40-e91b-450e-a4d9-0eb5d3a549ea)


We now have this:
![image](https://github.com/CatalaLang/catleg/assets/10352819/b225ff33-71f1-48e9-a29a-7c81b23813a1)

Seems cleaner to me?