### PR TITLE
Nota support in "catleg diff"

### DIFF
--- a/src/catleg/find_changes.py
+++ b/src/catleg/find_changes.py
@@ -39,7 +39,7 @@ async def find_changes(f: TextIO, *, file_path: Path | None = None):
 
         diff, retcode = wdiff(
             _reformat(article.text),
-            _reformat(ref_article.text),
+            _reformat(ref_article.text_and_nota()),
             return_exit_code=True,
             line_offset=article.start_line,
         )

--- a/src/catleg/query.py
+++ b/src/catleg/query.py
@@ -151,6 +151,11 @@ class LegifranceArticle(Article):
     def nota_html(self) -> str:
         return self._nota_html
 
+    def text_and_nota(self) -> str:
+        if len(self.nota):
+            return f"{self._text}\n\nNOTA :\n\n{self._nota}"
+        return self._text
+
     @property
     def type(self) -> ArticleType:
         return parse_article_id(self.id)[0]

--- a/tests/test_legifrance_queries.py
+++ b/tests/test_legifrance_queries.py
@@ -67,12 +67,14 @@ def test_no_extraneous_nota():
     article = _json_from_test_file("LEGIARTI000038814944.json")
     res = _article_from_legifrance_reply(article)
     assert "NOTA" not in res.to_markdown()
+    assert "NOTA" not in res.text_and_nota()
 
 
 def test_nota_format():
     article = _json_from_test_file("LEGIARTI000046790860.json")
     res = _article_from_legifrance_reply(article)
     assert "\n\nNOTA :\n\nConformément à l'article 89" in res.to_markdown()
+    assert "\n\nNOTA :\n\nConformément à l'article 89" in res.text_and_nota()
 
 
 def test_keep_newlines():


### PR DESCRIPTION
Handle notas in `catleg diff` the same way that we currently do for markdown skeleton generation.