### PR TITLE
remove first four lines from git diff output

### DIFF
--- a/src/catleg/find_changes.py
+++ b/src/catleg/find_changes.py
@@ -32,8 +32,11 @@ async def find_changes(f: TextIO, *, file_path: Path | None = None):
             line_offset=article.start_line,
         )
         if retcode != 0:
-            print(article.id)
-            print(f"{article.file_path or 'UNKNOWN_FILE'}:{article.start_line}")
+            print(article.id, flush=True)
+            print(
+                f"{article.file_path or 'UNKNOWN_FILE'}:{article.start_line}",
+                flush=True,
+            )
             sys.stdout.buffer.write(diff)
             diffcnt += 1
     if diffcnt > 0:

--- a/src/catleg/git_diff.py
+++ b/src/catleg/git_diff.py
@@ -34,7 +34,8 @@ def wdiff(st1: str, st2: str, *, return_exit_code=False, line_offset=0):
             capture_output=True,
             check=False,
         )
+        output = b"\n".join(result.stdout.splitlines()[4:])
         if return_exit_code:
-            return result.stdout, result.returncode
+            return output, result.returncode
         else:
-            return result.stdout
+            return output

--- a/src/catleg/git_diff.py
+++ b/src/catleg/git_diff.py
@@ -34,6 +34,9 @@ def wdiff(st1: str, st2: str, *, return_exit_code=False, line_offset=0):
             capture_output=True,
             check=False,
         )
+        # The four first lines of 'git diff' reference temporary
+        # files that we created for technical reasons and that are
+        # irrelevant to the user. Remove those lines.
         output = b"\n".join(result.stdout.splitlines()[4:])
         if return_exit_code:
             return output, result.returncode


### PR DESCRIPTION
This should help clean `catleg diff`, fixes #32 