### PR TITLE
fix catleg lf article command

### DIFF
--- a/src/catleg/catleg.py
+++ b/src/catleg/catleg.py
@@ -113,10 +113,12 @@ def lf_article(
     Retrieve an article from Legifrance.
     Outputs the raw Legifrance JSON representation.
     """
-    json.dumps(
-        _lf_article(aid_or_url),
-        indent=2,
-        ensure_ascii=False,
+    print(
+        json.dumps(
+            _lf_article(aid_or_url),
+            indent=2,
+            ensure_ascii=False,
+        )
     )
 
 


### PR DESCRIPTION
It looks like the latest release broke the `catleg lf article` command ; here's a fix, though I should probably add some end-to-end tests for the CLI