### PR TITLE
add legifrance credentials to ci pytest runs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,3 +31,5 @@ jobs:
         run: tox r --skip-pkg-install
         env:
           PYTEST_ADDOPTS: "-vv --durations=10"
+          CATLEG_LF_CLIENT_ID: ${{ secrets.CATLEG_LF_CLIENT_ID }}
+          CATLEG_LF_CLIENT_SECRET: ${{ secrets.CATLEG_LF_CLIENT_SECRET }}

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,9 @@ deps =
     pytest-sugar
 commands =
     pytest {posargs:tests}
+passenv =
+    CATLEG_LF_CLIENT_SECRET
+    CATLEG_LF_CLIENT_ID
 
 [testenv:type]
 description = run type checks


### PR DESCRIPTION
Stop skipping tests which rely on Legifrance credentials in order to gain better confidence in our CI runs